### PR TITLE
fix: production build hash showing correct git commit

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -3,7 +3,6 @@ name: Production Deploy
 on:
   push:
     tags: ['v*']
-    branches: ['fix/production-build-hash']
 
 jobs:
   production:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -3,6 +3,7 @@ name: Production Deploy
 on:
   push:
     tags: ['v*']
+    branches: ['fix/production-build-hash']
 
 jobs:
   production:
@@ -43,12 +44,21 @@ jobs:
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
           npm version $TAG_VERSION --no-git-tag-version
           echo "VERSION=$TAG_VERSION" >> $GITHUB_ENV
-          echo "NEXT_PUBLIC_BUILD_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       
-      - name: Build project
-        run: npm run build
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+      
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
         env:
-          NEXT_PUBLIC_BUILD_HASH: ${{ env.NEXT_PUBLIC_BUILD_HASH }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      
+      - name: Build project with Vercel
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       
       - name: Deploy to Vercel (Production)
         uses: amondnet/vercel-action@v41.1.4
@@ -56,4 +66,4 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-args: '--prod'
+          vercel-args: '--prod --prebuilt'

--- a/next.config.js
+++ b/next.config.js
@@ -23,8 +23,6 @@ const nextConfig = {
     NEXT_PUBLIC_APP_VERSION: version,
     NEXT_PUBLIC_BUILD_HASH: buildHash,
   },
-  // Optimize production builds
-  swcMinify: true,
   compiler: {
     removeConsole: process.env.NODE_ENV === 'production' ? {
       exclude: ['error', 'warn'],

--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,9 @@ const { execSync } = require('child_process');
 // Obter o hash do commit atual
 let buildHash = 'dev';
 try {
-  buildHash = execSync('git rev-parse --short HEAD').toString().trim();
+  // Usar variável de ambiente do Vercel se disponível
+  buildHash = process.env.VERCEL_GIT_COMMIT_SHA?.substring(0, 7) || 
+             execSync('git rev-parse --short HEAD').toString().trim();
 } catch (error) {
   console.warn('Não foi possível obter o hash do commit, usando "dev"');
 }


### PR DESCRIPTION
## Problem

Production builds were showing  in the footer instead of the actual git commit hash, while preview builds worked correctly.

## Root Cause

The production workflow was using 
> pharmacy-filter@1.0.0 build
> next build

   ▲ Next.js 15.5.9
   - Environments: .env.local, .env.production

   Linting and checking validity of types ...
   Creating an optimized production build ...
 ✓ Compiled successfully in 1083ms
   Collecting page data ...
   Generating static pages (0/5) ...
   Generating static pages (1/5) 
   Generating static pages (2/5) 
   Generating static pages (3/5) 
 ✓ Generating static pages (5/5)
   Finalizing page optimization ...
   Collecting build traces ...

Route (pages)                                 Size  First Load JS
┌ ƒ /                                      6.79 kB         214 kB
├   /_app                                      0 B         112 kB
├ ○ /404                                     180 B         113 kB
├ ƒ /api/pharmacies                            0 B         112 kB
├ ƒ /api/pharmacies/by-cnpj                    0 B         112 kB
├ ƒ /api/pharmacies/cities                     0 B         112 kB
├ ƒ /api/pharmacies/neighborhoods              0 B         112 kB
├ ƒ /api/pharmacies/states                     0 B         112 kB
├ ○ /favorites                             4.82 kB         212 kB
├ ● /sobre                                 1.93 kB         205 kB
└ ● /termos-de-uso                         1.94 kB         205 kB
+ First Load JS shared by all               112 kB
  ├ chunks/framework-a6e0b7e30f98059a.js   44.8 kB
  ├ chunks/main-abebd9d70c8fbe62.js          36 kB
  ├ chunks/pages/_app-5e332c75ef48140f.js  30.7 kB
  └ other shared chunks (total)              927 B

○  (Static)   prerendered as static content
●  (SSG)      prerendered as static HTML (uses getStaticProps)
ƒ  (Dynamic)  server-rendered on demand (local build) while preview was using  (which has access to Vercel environment variables like ).

## Solution

- ✅ Change production workflow to use  like preview
- ✅ Update  to use  when available
- ✅ Add  flag to production deploy step

## Result

Production footer now correctly shows the git commit hash instead of 'dev'.

## Testing

- ✅ Tested with temporary branch trigger - worked correctly
- ✅ All tests passing
- ✅ ESLint checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated production build and deployment workflow to use Vercel CLI, replacing the previous local build process with streamlined Vercel tooling integration.
  * Modified build hash retrieval to prioritize Vercel's environment variables while maintaining fallback compatibility.
  * Refined build optimization configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->